### PR TITLE
Move projects and resources to data files, update template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is the [jekyll](https://jekyllrb.com/) site behind the http://redcap-tools.github.io.
 
+## Adding projects & resources.
+
+The projects & resources tables on the [Projects](http://redcap-tools.github.io/projects/) are driven by [Jekyll Data files](http://jekyllrb.com/docs/datafiles/). Updating these tables simply requires a new row in the appropriate YAML files in the `_data` directory.
+
 ## Contributing
 
 * [Install jekyll](http://jekyllrb.com/docs/installation/)

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,21 +1,28 @@
+# Each record should contain:
+# name: (string) name of project
+# repo: (URL) canonical source for the project
+# repo_release: (URL), 
+# language: (string) the programming language 
+# docs: (URL) (optional) location for project documentation
+# description: (string) brief overview of the project. Links must use <a> tags.
 - name: GoCap
-  repo: https://github.com/tjrivera/go-cap)
+  repo: https://github.com/tjrivera/go-cap
   repo_release: https://img.shields.io/github/release/tjrivera/go-cap.svg
   language: Go
   description: A golang based library for REDCap. It provides helpful abstractions for making requests to REDCap's REST API. The project is currently in development and not considered production-ready.
 - name: nef-c-sharp
-  repo: https://github.com/redcap-tools/nef-c-sharp)
+  repo: https://github.com/redcap-tools/nef-c-sharp
   repo_release: https://img.shields.io/github/release/redcap-tools/nef-c-sharp.svg
   language: C#
   description: These functions push/pull <a href="https://msdn.microsoft.com/en-us/library/system.data.datatable.aspx">DataTables</a>.  It can be used in an .aspx program, or in a windows desktop program, a DET program, etc.
 - name: PhpCap
-  repo: https://github.com/aarenson/PhpCap)
+  repo: https://github.com/aarenson/PhpCap
   repo_release: https://img.shields.io/github/release/aarenson/PhpCap.svg
   language: PHP
   docs: https://github.com/aarenson/PhpCap/blob/master/README.md
   description: Provides classes that simplify the use of the REDCap application programming interface (API) using PHP.
 - name: PyCap
-  repo: https://github.com/redcap-tools/PyCap)
+  repo: https://github.com/redcap-tools/PyCap
   repo_release: https://img.shields.io/github/release/redcap-tools/PyCap.svg
   language: Python
   docs: http://pycap.readthedocs.org

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,0 +1,44 @@
+- name: GoCap
+  repo: https://github.com/tjrivera/go-cap)
+  repo_release: https://img.shields.io/github/release/tjrivera/go-cap.svg
+  language: Go
+  description: A golang based library for REDCap. It provides helpful abstractions for making requests to REDCap's REST API. The project is currently in development and not considered production-ready.
+- name: nef-c-sharp
+  repo: https://github.com/redcap-tools/nef-c-sharp)
+  repo_release: https://img.shields.io/github/release/redcap-tools/nef-c-sharp.svg
+  language: C#
+  description: These functions push/pull <a href="https://msdn.microsoft.com/en-us/library/system.data.datatable.aspx">DataTables</a>.  It can be used in an .aspx program, or in a windows desktop program, a DET program, etc.
+- name: PhpCap
+  repo: https://github.com/aarenson/PhpCap)
+  repo_release: https://img.shields.io/github/release/aarenson/PhpCap.svg
+  language: PHP
+  docs: https://github.com/aarenson/PhpCap/blob/master/README.md
+  description: Provides classes that simplify the use of the REDCap application programming interface (API) using PHP.
+- name: PyCap
+  repo: https://github.com/redcap-tools/PyCap)
+  repo_release: https://img.shields.io/github/release/redcap-tools/PyCap.svg
+  language: Python
+  docs: http://pycap.readthedocs.org
+  description: A minimal wrapper around the REDCap API to export & import data and files. It natively works with <a href="http://pandas.pydata.org">pandas</a>.
+- name: redcapAPI
+  repo: https://github.com/nutterb/redcapAPI
+  repo_release: https://img.shields.io/github/release/nutterb/redcapAPI.svg
+  language: R
+  docs: https://cran.r-project.org/web/packages/redcapAPI/redcapAPI.pdf
+  description: An R interface to REDCap, and is an actively developed fork of <a href="https://github.com/vubiostat/redcap">redcap</a>, originally created by <a href="https://github.com/jeffreyhorner">Jeffrey Horner</a>.
+- name: RedcapAPI
+  repo: https://github.com/eugyev/RedcapAPI
+  repo_release: https://img.shields.io/github/release/eugyev/RedcapAPI.svg
+  language: Ruby
+  description: An interface for REDCAP using ruby.
+- name: REDCap_API
+  repo: https://github.com/james2012/REDCap_API
+  repo_release: https://img.shields.io/github/release/james2012/REDCap_API.svg
+  language: JavaScript
+  description: To Access REDCap by API
+- name: REDCapR
+  repo: https://github.com/OuhscBbmc/REDCapR
+  repo_release: https://img.shields.io/github/release/OuhscBbmc/REDCapR.svg
+  language: R
+  docs: https://github.com/OuhscBbmc/REDCapR/blob/master/documentation_peek.pdf
+  description: Encapsulates functions to streamline calls from R to the REDCap API.

--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -1,3 +1,7 @@
+# Each record should contain:
+# name: (string)
+# link: (URL) location to point visitors
+# description: (text) High-level overview about the resource. Format links with <a> tags.
 - name: redcap-tools
   link: http://redcap-tools.github.io/
   description: REDCap-Tools is a GitHub organization that fosters interesting projects built against REDCap. Developers and projects in this organization have no official ties to REDCap other than looking to push the data management capabilities provided by REDCap’s more advanced tools (namely the API and Data Entry Triggers) to their fullest potential. (Edit the web site source code [here](https://github.com/redcap-tools/redcap-tools.github.io); view the repositories [here](https://github.com/redcap-tools).

--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -1,0 +1,6 @@
+- name: redcap-tools
+  link: http://redcap-tools.github.io/
+  description: REDCap-Tools is a GitHub organization that fosters interesting projects built against REDCap. Developers and projects in this organization have no official ties to REDCap other than looking to push the data management capabilities provided by REDCap’s more advanced tools (namely the API and Data Entry Triggers) to their fullest potential. (Edit the web site source code [here](https://github.com/redcap-tools/redcap-tools.github.io); view the repositories [here](https://github.com/redcap-tools).
+- name: API Troubleshooting Vignette
+  link: https://cdn.rawgit.com/OuhscBbmc/REDCapR/master/inst/doc/TroubleshootingApiCalls.html
+  description: There are many links in the pipeline between your institution's REDCap server and the API user. When the end result is unsuccessful, this document should help narrow the location of the possible problem. The first two sections will be relevant to almost any language interacting with the API. (Edit source code <a href="https://github.com/OuhscBbmc/REDCapR/blob/master/vignettes/TroubleshootingApiCalls.Rmd">here</a>).

--- a/projects.md
+++ b/projects.md
@@ -11,25 +11,45 @@ Below you'll find interesting projects built against either [REDCap](http://www.
 
 Several libraries exist for communicating with REDCap's API.  If one of these languages is available to you, they can help make your development quicker and more robust.
 
-| Project | Language<br/>(Documentation) | Description from its Repository|
-| :------ | :------: | :----------------------------- |
-| [GoCap](https://github.com/tjrivera/go-cap)<br/>[![GitHub release](https://img.shields.io/github/release/tjrivera/go-cap.svg)](https://github.com/tjrivera/go-cap) | Go | A golang based library for REDCap. It provides helpful abstractions for making requests to REDCap's REST API. The project is currently in development and not considered production-ready. |
-| [nef-c-sharp](https://github.com/redcap-tools/nef-c-sharp)<br/>[![GitHub release](https://img.shields.io/github/release/redcap-tools/nef-c-sharp.svg)](https://github.com/redcap-tools/nef-c-sharp) | C# | These functions push/pull [DataTable](https://msdn.microsoft.com/en-us/library/system.data.datatable.aspx)s.  It can be used in an .aspx program, or in a windows desktop program, a DET program, etc. |
-| [PhpCap](https://github.com/aarenson/PhpCap)<br/>[![GitHub release](https://img.shields.io/github/release/aarenson/PhpCap.svg)](https://github.com/aarenson/PhpCap) | PHP<br/>[(Documentation)](https://github.com/aarenson/PhpCap/blob/master/README.md) | Provides classes that simplify the use of the REDCap application programming interface (API) using PHP. |
-| [PyCap](https://github.com/redcap-tools/PyCap)<br/>[![GitHub release](https://img.shields.io/github/release/redcap-tools/PyCap.svg)](https://github.com/redcap-tools/PyCap) | Python<br/>[(Documentation)](http://pycap.readthedocs.org) | A minimal wrapper around the REDCap API to export & import data and files. It natively works with [pandas](http://pandas.pydata.org). |
-| [redcapAPI](https://github.com/nutterb/redcapAPI)<br/>[![GitHub release](https://img.shields.io/github/release/nutterb/redcapAPI.svg)](https://github.com/nutterb/redcapAPI) | R<br/>[(Documentation)](https://cran.r-project.org/web/packages/redcapAPI/redcapAPI.pdf) | An R interface to REDCap, and is an actively developed fork of [redcap](https://github.com/vubiostat/redcap), originally created by [Jeffrey Horner](https://github.com/jeffreyhorner). |
-| [RedcapAPI](https://github.com/eugyev/RedcapAPI)<br/>[![GitHub release](https://img.shields.io/github/release/eugyev/RedcapAPI.svg)](https://github.com/eugyev/RedcapAPI) | Ruby | An interface for REDCAP using ruby. |
-| [REDCap_API](https://github.com/james2012/REDCap_API)<br/>[![GitHub release](https://img.shields.io/github/release/james2012/REDCap_API.svg)](https://github.com/james2012/REDCap_API) | JavaScript | To Access REDCap by API. |
-| [REDCapR](https://github.com/OuhscBbmc/REDCapR)<br/>[![GitHub release](https://img.shields.io/github/release/OuhscBbmc/REDCapR.svg)](https://github.com/OuhscBbmc/REDCapR) | R<br/>[(Documentation)](https://github.com/OuhscBbmc/REDCapR/blob/master/documentation_peek.pdf) | Encapsulates functions to streamline calls from R to the REDCap API. |
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Project</th>
+      <th>Language</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for project in site.data.projects %}
+    <tr>
+      <td><a href="{{ project.repo }}">{{ project.name }}</a> <br /> <img src="{{ project.repo_release }}" alt="Github Release"></td>
+	  <td>{{ project.language }} {% if project.docs %} <br /> <a href="{{ project.docs }}">Documentation</a> {% endif %}</td>
+	  <td>{{ project.description }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 
 ## Common Resources
 
 The some developers of different libraries have collaborated to create resources not tied to any specific library.  The finished products and the source code are available on GitHub, and any contributions or suggestions are welcomed.
 
-| Resource | Description |
-| :------: | :---------- |
-| [redcap-tools](http://redcap-tools.github.io/) | REDCap-Tools is a GitHub organization that fosters interesting projects built against REDCap. Developers and projects in this organization have no official ties to REDCap other than looking to push the data management capabilities provided by REDCap’s more advanced tools (namely the API and Data Entry Triggers) to their fullest potential. (Edit the web site source code [here](https://github.com/redcap-tools/redcap-tools.github.io); view the repositories [here](https://github.com/redcap-tools).)|
-| [API Troubleshooting Vignette](https://cdn.rawgit.com/OuhscBbmc/REDCapR/master/inst/doc/TroubleshootingApiCalls.html) | There are many links in the pipeline between your institution's REDCap server and the API user. When the end result is unsuccessful, this document should help narrow the location of the possible problem. The first two sections will be relevant to almost any language interacting with the API. (Edit source code [here](https://github.com/OuhscBbmc/REDCapR/blob/master/vignettes/TroubleshootingApiCalls.Rmd).)|
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Resource</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for resource in site.data.resources %}
+    <tr>
+      <td><a href="{{ resource.link }}">{{ resource.name }}</a></td>
+	  <td>{{ resource.description }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 
 ## Remarks
 


### PR DESCRIPTION
Fixes #8 

By moving the projects and resource to data files we can:
1. Write actual HTML in the template (tables and markdown don't jive).
2. Make it easier for other devs to contribute their notes (no need to write html, just a few lines in the data files).

I used bootstrap's table classes to clean things up a bit.
