### PR TITLE
Change link to Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # redcap-tools.github.io
-[![Build Status](https://travis-ci.org/redcap-tools/redcap-tools.github.io.svg)](https://travis-ci.org/redcap-tools/redcap-tools.github.io)
+[![Build Status](https://travis-ci.org/redcap-tools/redcap-tools.github.io.svg?branch=master)](https://travis-ci.org/redcap-tools/redcap-tools.github.io)
 
 This is the [jekyll](https://jekyllrb.com/) site behind the http://redcap-tools.github.io.
 


### PR DESCRIPTION
The image/link wasn't working.  I copied this link from the Travis site.  Apparently we're now required to include the branch in the link.
