### PR TITLE
Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,16 @@ rvm:
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.
-script: ./scripts/cibuild
+# script: ./scripts/cibuild
 
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+
+# Follows advice of https://github.com/jekyll/jekyll/issues/3480
+install:
+  - gem install jekyll
+  - gem install html-proofer
+script:
+  - jekyll build
+  - htmlproof _site

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - gem install html-proofer
 script:
   - jekyll build
-  - htmlproof _site
+  - htmlproofer _site

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: ruby
 rvm:
 - 2.1
 
-# Assume bundler is being used, therefore
-# the `install` step will run `bundle install` by default.
-# script: ./scripts/cibuild
-
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
@@ -14,6 +10,7 @@ env:
 install:
   - gem install jekyll
   - gem install html-proofer
+
 script:
   - jekyll build
   - htmlproofer _site

--- a/_config.yml
+++ b/_config.yml
@@ -4,9 +4,12 @@ email: your-email@domain.com
 description: "REDCap-Tools, promoting awesome projects built atop REDCap and fostering a community of developers around them."
 baseurl: /
 url: "http://redcap-tools.github.io"
-twitter_username: 
-github_username: redcap-tools 
+twitter_username:
+github_username: redcap-tools
 
 # Build settings
 markdown: kramdown
 permalink: pretty
+
+#Don't explode on gems; https://jekyllrb.com/docs/continuous-integration/#configuring-your-travis-builds.
+exclude: [vendor]

--- a/_data/libraries.yml
+++ b/_data/libraries.yml
@@ -47,5 +47,5 @@
   repo: https://github.com/OuhscBbmc/REDCapR
   repo_release: https://img.shields.io/github/release/OuhscBbmc/REDCapR.svg
   language: R
-  docs: https://github.com/OuhscBbmc/REDCapR/blob/master/documentation_peek.pdf
+  docs: https://github.com/OuhscBbmc/REDCapR/blob/master/documentation-peek.pdf
   description: Encapsulates functions to streamline calls from R to the REDCap API.

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e # halt script on error
-
-bundle exec jekyll build
-bundle exec htmlproof ./_site


### PR DESCRIPTION
@sburns, something apparently changed with htmlproof/htmlproofer.  A [Jekyll issue](https://github.com/jekyll/jekyll/issues/3480) demonstrated how to use htmlproofer with a `scripts/cibuild`.

Do you have any preference?  I don't have much experience in this area. 

In hindsight, it's probably as simple changing `bundle exec htmlproof ./_site` to `bundle exec htmlproofer ./_site` in cibuild.  (Here's a [failing build example](https://travis-ci.org/redcap-tools/redcap-tools.github.io/builds/153459359).)
