### PR TITLE
R documentation points to live website

### DIFF
--- a/_data/libraries.yml
+++ b/_data/libraries.yml
@@ -36,7 +36,7 @@
   repo: https://github.com/nutterb/redcapAPI
   repo_release: https://img.shields.io/github/release/nutterb/redcapAPI.svg
   language: R
-  docs: https://cran.r-project.org/web/packages/redcapAPI/redcapAPI.pdf
+  docs: https://www.rdocumentation.org/packages/redcapAPI
   description: An R interface to REDCap, and is an actively developed fork of <a href="https://github.com/vubiostat/redcap">redcap</a>, originally created by <a href="https://github.com/jeffreyhorner">Jeffrey Horner</a>.
 - name: RedcapAPI
   repo: https://github.com/eugyev/RedcapAPI
@@ -52,5 +52,5 @@
   repo: https://github.com/OuhscBbmc/REDCapR
   repo_release: https://img.shields.io/github/release/OuhscBbmc/REDCapR.svg
   language: R
-  docs: https://github.com/OuhscBbmc/REDCapR/blob/master/documentation-peek.pdf
+  docs: https://www.rdocumentation.org/packages/REDCapR/
   description: Encapsulates functions to streamline calls from R to the REDCap API.


### PR DESCRIPTION
I like your suggestion, @rparrish.  Is this what you had in mind?  Closes #27.

@nutterb, tell me if you want your documentation to point back to the CRAN pdf.