### PR TITLE
Added REDCap-ETL application information

### DIFF
--- a/_data/applications.yml
+++ b/_data/applications.yml
@@ -1,10 +1,9 @@
 # Each record should contain:
 # name: (string)
-# link: (URL) location to point visitors
+# repo: (URL) location of application code
+# language: main programming language of application
 # description: (text) High-level overview about the resource. Format links with <a> tags.
-- name: External Modules Repository
-  link: https://redcap.vanderbilt.edu/consortium/modules/index.php
-  description:  The REDCap Repo is a centralized repository of curated External Modules that can be installed by a REDCap administrator.  External Modules are add-on packages that extend functionality, either at the system level or project level.
 - name: REDCap-ETL
-  link: https://github.com/IUREDCap/redcap-etl
+  repo: https://github.com/IUREDCap/redcap-etl
+  language: PHP
   description:  REDCap-ETL (REDCap Extract, Transform, Load) is an application that can extract data from REDCap, transform the extracted data, and load the transformed data into a database.

--- a/projects.md
+++ b/projects.md
@@ -83,7 +83,7 @@ These samples can be copied and pasted into a larger program.  Some of the sampl
 Applications
 ---------------------
 
-These projects extend REDCap capabilities and facilitate integration with other systems.
+These programs or scripts extend REDCap capabilities and facilitate integration with other systems.
 
 <table class="table table-striped">
   <thead>
@@ -91,16 +91,14 @@ These projects extend REDCap capabilities and facilitate integration with other 
       <th>Project</th>
       <th>Language</th>
       <th>Description</th>
-      <th>Release</th>
     </tr>
   </thead>
   <tbody>
   {% for sample in site.data.applications %}
     <tr>
-      <td><a href="{{ sample.repo }}">{{ sample.name }}</a></td>
-      <td>{{ sample.language }}</td>
-      <td>{{ sample.description }}</td>
-      <td><img src="{{ sample.repo_release }}" alt="GitHub Release"> {% if sample.docs %} <br /> <a href="{{ sample.docs }}">Documentation</a> {% endif %}</td>
+      <td><a href="{{ application.repo }}">{{ application.name }}</a></td>
+      <td>{{ application.language }}</td>
+      <td>{{ application.description }}</td>
     </tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
I added information on the REDCap-ETL application. My modifications consider an application to be a program or script that you would download to your system and run. It is something that can be run on its own, so external modules would not be included here, since they are extensions to REDCap that have to be run within REDCap, and libraries would not be included here, since they are called by an application that is run. In this context, I would consider the external module repo to be a website and not an application.